### PR TITLE
Add getRSSI() function to retrieve signal strength

### DIFF
--- a/CC1101_ESP_Arduino.cpp
+++ b/CC1101_ESP_Arduino.cpp
@@ -313,3 +313,15 @@ uint8_t CC1101::getVersion(){
 uint8_t CC1101::log2(double value){
 	return log10(value) / log10(2);
 }
+int8_t CC1101::getRSSI(){
+    uint8_t rssi_dec = spiReadStatus(CC1101_RSSI);
+    int8_t rssi_dbm;
+    
+    if (rssi_dec >= 128) {
+        rssi_dbm = ((int16_t)rssi_dec - 256) / 2 - 74;
+    } else {
+        rssi_dbm = (int16_t)rssi_dec / 2 - 74;
+    }
+    
+    return rssi_dbm;
+}

--- a/CC1101_ESP_Arduino.h
+++ b/CC1101_ESP_Arduino.h
@@ -214,6 +214,7 @@ class CC1101 {
 		void setDeviationHZ(int deviation_hz); //1586hz - 380859hz
 		uint8_t getPartnum();
 		uint8_t getVersion();
+		int8_t getRSSI();
 		
 		void spiStrobe(uint8_t strobe);
 		uint8_t spiReadReg(uint8_t addr);

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ void setModulation(MOD_FORMAT mod);
 void setDeviationHZ(int deviation_hz); //1586hz - 380859hz
 uint8_t getPartnum();
 uint8_t getVersion();
+int8_t getRSSI();
 ```
 
 ### Low level methods:


### PR DESCRIPTION
Hi!
First, thanks for this great library.
It really helped me get to grips with the CC1101 transceiver.

While working with the library, I realized that I needed to monitor the signal strength of the incoming packets.
Therefore, I have implemented a new function to read the RSSI value.
I added the readRSSI() function and updated README.md to include usage details.

I have tested the function on my local setup (Arduino/ESP32) with the CC1101 module, and the values accurately reflect the signal changes when moving the transmitter.

Thanks for maintaining this great library! I hope this addition is useful for others as well.