### PR TITLE
Feature/multi spi support

### DIFF
--- a/CC1101_ESP_Arduino.cpp
+++ b/CC1101_ESP_Arduino.cpp
@@ -18,13 +18,14 @@
 
 /****************************************************************/
 
-CC1101::CC1101(int8_t sck, int8_t miso, int8_t mosi, int8_t cs, int8_t gdo0, int8_t gdo2){
+CC1101::CC1101(int8_t sck, int8_t miso, int8_t mosi, int8_t cs, int8_t gdo0, int8_t gdo2, SPIClass *spiInstance){
 	SCK_PIN = sck;
 	MISO_PIN = miso;
 	MOSI_PIN = mosi;
 	SS_PIN = cs;
 	GDO0 = gdo0;
 	GDO2 = gdo2;
+	_spi = spiInstance;
 }
 
 void CC1101::spiStart(){
@@ -41,18 +42,18 @@ void CC1101::spiStart(){
 	}
 
 	#if defined ESP32
-	SPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
+	_spi->begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
 	#else
-	SPI.begin();
+	_spi->begin();
 	#endif
 }
 
 void CC1101::spiEnd(){
-	SPI.end();
+	_spi->end();
 }
 
 void CC1101::spiStartTransaction(){
-	SPI.beginTransaction(spiSettings);
+	_spi->beginTransaction(spiSettings);
 	digitalWrite(SS_PIN, LOW);
 	while(digitalRead(MISO_PIN)){
 	 	yield();
@@ -60,17 +61,14 @@ void CC1101::spiStartTransaction(){
 }
 
 void CC1101::spiEndTransaction(){
-	//while(digitalRead(MISO_PIN)){
-	//	yield();
-	//};
 	delay(1);
 	digitalWrite(SS_PIN, HIGH);
-	SPI.endTransaction();
+	_spi->endTransaction();
 }
 
 void CC1101::spiStrobe(uint8_t strobe){
 	spiStartTransaction();
-	SPI.transfer(strobe);
+	_spi->transfer(strobe);
 	spiEndTransaction();
 }
 
@@ -78,8 +76,8 @@ uint8_t CC1101::spiReadReg(uint8_t addr){
 	uint8_t temp, value;
 	temp = addr| READ_SINGLE;
 	spiStartTransaction();
-	SPI.transfer(temp);
-	value=SPI.transfer(0);
+	_spi->transfer(temp);
+	value=_spi->transfer(0);
 	spiEndTransaction();
 	return value;
 }
@@ -88,8 +86,8 @@ uint8_t CC1101::spiReadStatus(uint8_t addr){
 	uint8_t value,temp;
 	temp = addr | READ_BURST;
 	spiStartTransaction();
-	SPI.transfer(temp);
-	value=SPI.transfer(0);
+	_spi->transfer(temp);
+	value=_spi->transfer(0);
 	spiEndTransaction();
 	return value;
 }
@@ -98,17 +96,17 @@ void CC1101::spiReadRegBurst(uint8_t addr, uint8_t *buffer, uint8_t buffer_len){
 	uint8_t temp;
 	temp = addr | READ_BURST;
 	spiStartTransaction();
-	SPI.transfer(temp);
+	_spi->transfer(temp);
 	for(uint8_t i = 0; i < buffer_len; i++){
-		buffer[i]=SPI.transfer(0);
+		buffer[i]=_spi->transfer(0);
 	}
 	spiEndTransaction();
 }
 
 void CC1101::spiWriteReg(uint8_t addr, uint8_t value){
 	spiStartTransaction();
-	SPI.transfer(addr);
-	SPI.transfer(value);
+	_spi->transfer(addr);
+	_spi->transfer(value);
 	spiEndTransaction();
 }
 
@@ -116,9 +114,9 @@ void CC1101::spiWriteRegBurst(uint8_t addr, const uint8_t *buffer, uint8_t buffe
 	uint8_t temp;
 	temp = addr | WRITE_BURST;
 	spiStartTransaction();
-	SPI.transfer(temp);
+	_spi->transfer(temp);
 	for (uint8_t i = 0; i < buffer_len; i++) {
-		SPI.transfer(buffer[i]);
+		_spi->transfer(buffer[i]);
 	}
 	spiEndTransaction();
 }
@@ -176,7 +174,7 @@ void CC1101::hardReset(){
 	digitalWrite(SS_PIN, HIGH);
 	delay(1);
 	spiStartTransaction();
-	SPI.transfer(CC1101_SRES);
+	_spi->transfer(CC1101_SRES);
 	spiEndTransaction();
 	spiStrobe(CC1101_SCAL);
 }

--- a/CC1101_ESP_Arduino.h
+++ b/CC1101_ESP_Arduino.h
@@ -193,10 +193,11 @@ class CC1101 {
 		int8_t GDO0; //TX or TX/RX
 		int8_t GDO2; //RX
 		
+		SPIClass *_spi;
 		SPISettings spiSettings = SPISettings(10000000, MSBFIRST, SPI_MODE0);
 
 	public:
-		CC1101(int8_t sck, int8_t miso, int8_t mosi, int8_t cs, int8_t gdo0, int8_t gdo2=-1);
+		CC1101(int8_t sck, int8_t miso, int8_t mosi, int8_t cs, int8_t gdo0, int8_t gdo2=-1, SPIClass *spiInstance=&SPI);
 		
 		void init();
 		void softReset();

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ In other words, you can't use the more flexible serial mode.
 
 * You can also use the GDOx pins for something else. Again, that's what the low level SPI methods are for.
 
+### Using a custom SPI bus instance
+Some boards have peripherals permanently wired to the default SPI bus, leaving it unavailable for the CC1101.
+A good example is the [Waveshare ESP32-S3-ETH](https://www.waveshare.com/wiki/ESP32-S3-ETH), which has an onboard W5500 Ethernet chip connected to the default SPI bus.
+
+In such cases, pass a secondary SPI instance to the constructor:
+```cpp
+SPIClass hspi(HSPI);
+CC1101 cc1101(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS, CC1101_GDO0, -1, &hspi);
+```
+
+If no `spiInstance` is provided, the library defaults to `&SPI` and behaves exactly as before.
+
 ## API
 
 ### Constructors:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ If no `spiInstance` is provided, the library defaults to `&SPI` and behaves exac
 ```cpp
 CC1101(int sck, int miso, int mosi, int cs, int gdo0);
 CC1101(int sck, int miso, int mosi, int cs, int gdo0, int gdo2);
+CC1101(int sck, int miso, int mosi, int cs, int gdo0, int gdo2, SPIClass *spiInstance);
 ```
 
 ### High level methods:


### PR DESCRIPTION
Hi! 

While working on a project using the Waveshare ESP32-S3-ETH board, I ran into an issue: the board has an onboard W5500 Ethernet chip permanently wired to the default SPI bus, leaving it unavailable for the CC1101.

To solve this, I added an optional `SPIClass *spiInstance` parameter to the constructor. All internal SPI calls now use the injected instance instead of the global `SPI` object directly. This allows the CC1101 to be used on any available SPI bus, like HSPI on ESP32:

```cpp
SPIClass hspi(HSPI);
CC1101 cc1101(CC1101_SCK, CC1101_MISO, CC1101_MOSI, CC1101_CS, CC1101_GDO0, -1, &hspi);
```

The parameter defaults to `&SPI`, so the change is fully backwards compatible and existing code requires no modifications.

I also updated README.md to document the new parameter and added a wiring example for boards with a shared SPI bus.

I have tested this on my Waveshare ESP32-S3-ETH with the W5500 on the default SPI bus and the CC1101 on HSPI — everything works as expected.

This is already my second contribution to this library^^
It keeps proving itself useful in my projects, so I’m happy to give something back. I hope this addition helps others running into the same situation!